### PR TITLE
format: try to make pdf formated more like ac spec

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -226,8 +226,9 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'CounterMitm.tex', u'Counter Mitm Documentation',
-     u'azul', 'manual'),
+    (master_doc, 'CounterMitm.tex',
+    u'Detecting active attacks against Autocrypt',
+     u'azul, hpk and others', 'howto'),
 ]
 
 # For "manual" documents, if this is true, then toplevel headings are parts,

--- a/source/gossip.rst
+++ b/source/gossip.rst
@@ -36,11 +36,16 @@ Attack Scenarios
 Attacking group communication on a single connection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-|Targetted attack on a single connection| The attacker intercepts the
-initial message from Alice to Bob (1) and replaces Alices key ``a`` with
-a mitm key ``a'`` (2). When Bob replies (3) the attacker decrypts the
-message, replaces Bobs key ``b`` with ``b'``, encrypts the message to
-``a`` and passes it on to Alice (4).
+.. figure:: ../images/no_gossip.*
+   :alt: Targetted attack on a single connection
+
+   Targetted attack on a single connection
+
+
+The attacker intercepts the initial message from Alice to Bob (1) and
+replaces Alices key ``a`` with a mitm key ``a'`` (2). When Bob replies
+(3) the attacker decrypts the message, replaces Bobs key ``b`` with
+``b'``, encrypts the message to ``a`` and passes it on to Alice (4).
 
 Both Bob and Alice also communicate with Claire (5,6,7,8). Even if the
 attacker chooses to not attack this communication the attack on a single
@@ -285,6 +290,4 @@ contexts similar to mailing lists it may be interesting to provide
 confidentiality guarantees without revealing who met whom for
 out-of-band verification. Notice however that the idea of key gossip
 does not allow for recipient anonymity.
-
-.. |Targetted attack on a single connection| image:: ../images/no_gossip.*
 


### PR DESCRIPTION
Mainly changed the document class from manual to howto.
This reduces the number of empty pages at the beginning.
Also converted one included graph into a figure so it
shows up with a number and has an alt text etc.