### PR TITLE
verified contact: only alice needs to send vc-confirm

### DIFF
--- a/source/new.rst
+++ b/source/new.rst
@@ -126,14 +126,12 @@ work flow for establishing a secure contact between two contacts, Alice and Bob.
 
    If any verification fails, Alice's device signals "Could not establish
    secure connection to Bob" and the protocol terminates.
+   Otherwise it shows "Secure contact with Bob <bob-adr> established".
 
-6. Alice and Bob send "vc-contact-confirm" messages to each other:
+6. Alice sends Bob a "vc-contact-confirm" message:
 
-   a) Bob receives "vc-confirm" and
-      shows "Secure contact with Alice <alice-adr> established".
-
-   b) Alice receives "vc-confirm" and
-      shows "Secure contact with Bob <bob-adr> established".
+   Bob receives "vc-confirm" and
+   shows "Secure contact with Alice <alice-adr> established".
 
 
 Message layer attackers can not impersonate Bob nor Alice


### PR DESCRIPTION
Once Alice has performed step 5 and everything checks out
she has a valid key for Bob that has been 'authenticated'
by proving knowledge of the secret.

If things had failed on Bob's end she had never received the
'vc-request-with-auth'.

The only thing that could go wrong now is her 'vc-confirm'
message not arriving to Bob. In that case they both could
already send encrypted messages to each other and the channel
would be secured. But on Bob's side the handshake would seem
unterminated because Bob can not be sure Alice received his
reply.

However adding another 'vc-confirm' message just switches
the problem around. Now Alice might be left in an open
confirmation process if Bob's 'vc-confirm' gets lost.

**update:** Actually i think 'vc-confirm' can be dropped entirely and we
end the process stating success on each device when we
know we have a verified key for the other person.