### PR TITLE
fix #34

### DIFF
--- a/source/new.rst
+++ b/source/new.rst
@@ -19,16 +19,17 @@ prior verifications, requiring the tedious task of redoing them all.
 In practice, very few users consistently perform key verification.
 This is true for users of Signal, Threema, Wire and Whatsapp.
 
-A traditional approach to reducing the necessity of out-of-band
-verification is the web of trust. Existing implementations such as the
-OpenPGP keyservers however publicly leak the social graph and require a
-substantial learning effort to understand the underlying concepts.
-They have reached very limited adoption. Autocrypt intentionally
-does not use public keyservers.
+A traditional approach to reducing the number of neccessary key verifications
+is the web of trust. It requires a substantial learning effort for users
+to understand the underlying concepts. Moreover, with OpenPGP the web of trust
+is usually interacting with OpenPGP key servers
+which however publicly leak the social "trust" graph.
+Both key servers and the web of trust have reached very limited adoption.
+Autocrypt therefore does not use public keyservers or the web of trust.
 
 In this section, we consider how introducing new kinds of (hidden)
 messages and workflows between peers can substantially help
-with maintaining communication security against active
+with maintaining end-to-end security against active
 attacks from providers or the network. The described protocols
 are decentralized in that they describe ways of how peers (or
 their devices) can interact with each other, thus fitting nicely
@@ -49,7 +50,8 @@ The setup-verified-contact protocol is safe against message layer modification a
 message layer impersonation attacks
 as both peers will learn the true keys of each other or else both get an error message.
 This is achieved in a single simple UI workflow, in that a peer
-"shows" out-of-band data that is then "read" by the other peer.  On mobiles such
+"shows" bootstrap data that is then "read" by the other peer through a trusted channel.
+On mobiles such
 a trusted channel is typically achieved with QR codes but transfering data via
 USB, Bluetooth, WLAN channels or phone calls is possible as well.
 A trusted channel is characterized by
@@ -61,7 +63,7 @@ keys of each other.
 Here is a conceptual step-by-step example of the proposed UI and administrative message
 workflow for establishing a secure contact between two contacts, Alice and Bob.
 
-1. Alice sends a bootstrap code to Bob via a trusted (Out-of-Band) channel.
+1. Alice sends a bootstrap code to Bob through a trusted (Out-of-Band) channel.
    The bootstrap code consists of:
 
    - Alice's Openpgp4 public key fingerprint ``Alice_FP``,
@@ -156,7 +158,7 @@ Open Questions
 
 .. _`verified-group`:
 
-Out-of-band verified groups
+Verified Groups
 ---------------------------
 
 We introduce a new secure **verified group** which is consistently secure
@@ -250,8 +252,9 @@ Notes on the verified group protocol
   group protocol would thus contribute to securing the e-mail encryption eco-system,
   rather than just securing the group at hand.
 
-- **full out-of-band**: messages from step 2 on could be transferred via
-  Bluetooth or WLAN to fully perform the invite/join protocol out-of-band.
+- **send all protocol messages through trusted channel**:
+  messages from step 2 on could be transferred via
+  Bluetooth or WLAN to fully perform the invite/join protocol in a trusted channel.
   The provider would not gain knowledge about verifications.
 
 - **non-messenger e-mail apps**: instead of groups, traditional e-mail apps could
@@ -279,20 +282,20 @@ verification network in the initial thread?
 
 .. _`keyhistory-verification`:
 
-Out-of-band Key history verification
+Key history verification
 ------------------------------------
 
 We present a "keyhistory-verification" techno-social protocol which
 improves on the current situation:
 
 - the detection of active attacks is communicated when users engage in
-  out-of-band verification which is the right time to alert users.
+  key verification workflows which is the right time to alert users.
   By contrast, today's key verification workflows alert the users when a
   previously verified key has changed, but at that point users typically
   are not physically next to each other and want to get a different job done,
   e.g. of sending or reading a message.
 
-- peers need to perform only one "show" and one "read" of out-of-band
+- peers need to perform only one "show" and one "read" of bootstrap
   information (typically transmitted via showing QR codes and scanning them).
   Both peers receive assessments about the integrity of their past communication.
   By contrast, current key fingerprint verification workflows (signal, whatsapp)

--- a/source/summary.rst
+++ b/source/summary.rst
@@ -15,22 +15,22 @@ e-mail encryption community efforts.
 
 We only consider those active attacks in which the messaging layer (e.g.
 the e-mail provider, network router) is malfeasant and all peers are honest.
-The messaging layer is also characterized as an "in-band", "untrusted" channel.
+The messaging layer is refered to as an "in-band", "untrusted" channel.
+Any defense against active attacks requires end-user key verification through
+trusted channels, i. e. peers verifying their respective keys in ways
+that can not be manipulated by the untrusted message layer.
 
-Any defense against active attacks requires end-user key verification,
-i. e. peers verifying their respective keys in ways that can not be manipulated
-by the untrusted in-band message layer.
-We refer to in-band key distribution if a single entity relays both
-messages and keys (e.g. Autocrypt, Web Key Directory, Signal's keyserver).
-With in-band key distribution, users who do not perform
-key verification through an out-of-band channel are vulnerable
-to active message layer attacks.
+If a single entity relays both messages and keys (e.g. Autocrypt,
+Web Key Directory, Signal's keyserver) then users are vulnerable
+to active attacks from this entity, unless they perform
+bidirectional key verification through a trusted channel.
+We sometimes also refer to trusted channels as "out-of-band" channels.
 
 With existing e2e-encrypting messengers (Signal, Whatsapp, Threema etc.)
-users perform key verification by triggering an extra fingerprint validation workflow:
-two peers each show and read Out-of-Band data (a QR code typically)
-to verify their current key fingerprints.  We observe the following issues with
-these schemes:
+users perform key verification by triggering two extra fingerprint validation workflows:
+The two peers each show and read key fingerprint data through a trusted channel
+(a QR code show+scan typically) to verify their current key fingerprints.
+We observe the following issues with these schemes:
 
 - The two peers need to start two validation workflows to assert
   that both of their encryption keys are not manipulated.
@@ -53,13 +53,13 @@ by integrating key verification into existing messaging use cases:
 
 - the :ref:`Setup Contact protocol <setup-contact>` allows a user
   to establish a verified contact with another user.
-  Out-of-band data, shown by one peer and read by the other,
-  transfers not only fingerprint but also addressing information
-  so that there is no need to type in addresses on initial contact.
+  The out-of-band bootstrap data, shown by one peer and read by the other through
+  a trusted channel, transfers not only fingerprint but also addressing
+  information so that there is no need to type in addresses on initial contact.
 
 - the :ref:`verified group protocol <verified-group>` extends the
   previous setup-contact protocol.
-  The initial out-of-band data is presented as an invite code.
+  The bootstrap data functions as an invite code to the group.
   The "joining" peer establishes verified contact and the inviter
   then announces the joiner as a new member. Any member may invite new members.
   All members of a verified group are consistently connected


### PR DESCRIPTION
rather than out-of-band/in-band use "trusted" versus "untrusted" channels ...
a more common terminology in cryptography ASFAIU.