### PR TITLE
lock keys for verified contacts and groups

### DIFF
--- a/source/new.rst
+++ b/source/new.rst
@@ -253,6 +253,28 @@ Notes on the verified group protocol
   could possibly offer the techniques described here for "secure threads".
 
 
+Autocrypt and verified key state
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Verified key material
+- whether from verified contacts or verified groups -
+provides stronger security guarantees
+then keys discovered in Autocrypt headers.
+
+Therefore the address key mappings should be stored separately
+and used over Autocrypt keys in case of conflicts.
+
+This way verified contacts and groups prevent key injection through
+Autocrypt headers.
+
+In order to allow users to recover from device loss
+the recommendation is to perform new verifications.
+
+Since this may not always be feasible
+clients should provide the users with a way
+to actively move back to an unverified state.
+
+
 Open Questions about reusing verifications for new groups
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
#49 made it clear that we have not spelled this out.

I think we need to actually lock the keys to uphold the security properties in the face of active attacks such as fabricated Autocrypt headers.