### PR TITLE
Clarify vc-contact-confirm *needs* to be encrypted

### DIFF
--- a/source/new.rst
+++ b/source/new.rst
@@ -279,7 +279,7 @@ Alice and Bob.
 
    a) shows "Secure contact with Bob <bob-adr> established".
 
-   b) sends Bob a "vc-contact-confirm" message.
+   b) sends Bob a encrypted "vc-contact-confirm" message.
 
    c) also removes the data associated with ``INVITENUMBER``.
 
@@ -289,10 +289,12 @@ Alice and Bob.
 
 At the end of this protocol,
 Alice has learned and validated the contact information and Autocrypt key of Bob,
-the person to whom she sent the bootstrap code.
+the person to whom she sent the bootstrap code,
+while also knowing that Bob has her Autocrypt key.
 Moreover,
 Bob has learned and validated the contact information and Autocrypt key of Alice,
-the person who sent the bootstrap code to Bob.
+the person who sent the bootstrap code to Bob,
+while also knowing that Alice has his Autocrypt key.
 
 Requirements for the underlying encryption scheme
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Also attempt to explain a little more what both parties know at the
end of the protocol.  This strictly says it is bi-directional
verification that is achieved.

Attempt to fix #83 